### PR TITLE
修复了在网易云和 QQ 音乐页面的行为

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,7 @@
 chrome.webRequest.onBeforeRequest.addListener(
   function(info) {
-    if (info.type === 'other' || info.type === 'object' || info.type === 'media') {
+    console.log(info)
+    if (info.type === 'other' || info.type === 'object' || info.type === 'media' || (info.type === 'xmlhttprequest' && info.tabId > 0)) {
       chrome.tabs.sendMessage(info.tabId, {desc: JSON.stringify(info), url: info.url, format: 'mp3', type: 'music'});
       console.log('info sent0');
       console.log(info.requestBody);

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -97,7 +97,7 @@ onMsg.addListener(
       } else if(thisUrl.indexOf('play.baidu.com') > 0) {
         filename = document.title.substr(0, document.title.indexOf(' - 百度音乐盒'));
       } else if(thisUrl.indexOf('y.qq.com') > 0) {
-        filename = $('#divplayer p.music_name').text() + ' - ' + $('#divplayer .music_info_main .singer_name').text();
+        filename = $('#sim_song_info').text();
       } else if(thisUrl.indexOf('music.163.com') > 0) {
         filename = $('.play .words .fc1').text() + ' - ' + $('.play .words .by').text();
       } else if(thisUrl.indexOf('ting.sina.com.cn') > 0) {


### PR DESCRIPTION
### 5b7bc22
在我使用的 Firefox 64.0.2 中，网易云加载的网络包的类型是 xmlhttprequest ；具体内容如下：
```
documentUrl: "https://music.163.com/#/my/m/music/playlist?id=..."
frameAncestors: Array []
frameId: 0
ip: null
method: "OPTIONS"
originUrl: "https://music.163.com/#/my/m/music/playlist?id=..."
parentFrameId: -1
proxyInfo: null
requestId: "5749"
tabId: 41
timeStamp: 1549195693411
type: "xmlhttprequest"
url: "https://m10.music.126.net/2019..."
```

### 4eedd54
QQ 音乐播放器似乎又改版了？